### PR TITLE
Sort blocks in "Find Blocks" view by name

### DIFF
--- a/BlockFinderPanelController.mm
+++ b/BlockFinderPanelController.mm
@@ -64,7 +64,7 @@ BOOL color_stored = NO;
     // Populate the Blockfinder Menu
     
     [blockSelector setAutoenablesItems:NO];
-    for (NSString* tilename in [minecraft_blocks keysSortedByValueUsingSelector:@selector(compare:)]) 
+    for (NSString* tilename in [[minecraft_blocks allKeys] sortedArrayUsingSelector:@selector(compare:)])
     {
         NSMenuItem* tileitem = [[NSMenuItem alloc] initWithTitle:tilename action:@selector(selectBlock:) keyEquivalent:@""]; 
         [blockFinderMenu addItem:tileitem];


### PR DESCRIPTION
This is just a tweak so that blocks in the "Find Blocks" dialog are sorted by name, rather than ID. That always bothered me. So, here's a patch to take care of it. 

Enjoy!
